### PR TITLE
Fix form rendering and model repr in quicknotes

### DIFF
--- a/quicknotes/models.py
+++ b/quicknotes/models.py
@@ -8,4 +8,4 @@ class Note(models.Model):
         return self.title
 
     def __repr__(self):
-        return __str__()
+        return self.__str__()

--- a/quicknotes/views.py
+++ b/quicknotes/views.py
@@ -9,7 +9,7 @@ def home(request):
 
 def notes(request):
     data = Note.objects.all()
-    return render(request, 'quicknotes/index.html', {'notes': data, 'form': NoteForm})
+    return render(request, 'quicknotes/index.html', {'notes': data, 'form': NoteForm()})
     
 def note(request, note_id):
     data = get_object_or_404(Note, pk=note_id)


### PR DESCRIPTION
## Summary
- Pass a NoteForm instance to the notes template so the add form renders correctly
- Ensure Note model's __repr__ returns the string representation to avoid TypeError

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a3ba28d3c8323be2e81fc94620199