### PR TITLE
Fix stylesheet link HTML syntax

### DIFF
--- a/quicknotes/templates/quicknotes/quicknotes.html
+++ b/quicknotes/templates/quicknotes/quicknotes.html
@@ -5,7 +5,7 @@
         <title>{% block title %}QuickNotes{% endblock %}</title>
 
         {% load static %}
-        <link rel="stylesheet", href="{% static 'quicknotes/styles.css' %}">
+        <link rel="stylesheet" href="{% static 'quicknotes/styles.css' %}">
     </head>
 
     <body>


### PR DESCRIPTION
## Summary
- remove stray comma in quicknotes stylesheet link

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b75e821c883239978761253547f84